### PR TITLE
Additional fixes for compatibility with webapp

### DIFF
--- a/dist/rainbow.js
+++ b/dist/rainbow.js
@@ -158,12 +158,6 @@
      * @return {Worker}
      */
     function createWorker(fn, Prism) {
-        if (isNode$1()) {
-            /* globals global, require, __filename */
-            global.Worker = require('webworker-threads').Worker;
-            return new Worker(__filename);
-        }
-
         var prismFunction = Prism.toString();
 
         var code = keys.toString();

--- a/src/language/generic.js
+++ b/src/language/generic.js
@@ -1,4 +1,6 @@
-    /**
+const Rainbow = require('../../dist/rainbow.js');
+
+/**
  * Generic language patterns
  *
  * @author Craig Campbell

--- a/src/language/javascript.js
+++ b/src/language/javascript.js
@@ -1,3 +1,5 @@
+const Rainbow = require('../../dist/rainbow.js');
+
 /**
  * Javascript patterns
  *


### PR DESCRIPTION
I ran into a few issues while trying to run the tests on the rainbow-using code. It tried to find webworker_threads because of the require statement, so I deleted it. 

I also realized that I wasn't seeing the rainbow highlighting (I thought I was before, but I was seeing our own highlighting). That was due to missing the language files. So this diff makes the language files require()able in webapp by putting require() statements in them. Note I didn't touch the other many language files, and I didn't add the html.js file, despite it being referenced before, because only our JS challenges currently use the rainbow highlighting.